### PR TITLE
Set the crt, key and bundle fields using setPlain

### DIFF
--- a/src/Formats/Plain.php
+++ b/src/Formats/Plain.php
@@ -54,6 +54,18 @@ class Plain extends AbstractFormat
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function setPlain(Plain $plain): FormatInterface
+    {
+        $this->crt = $plain->getCrt();
+        $this->key = $plain->getKey();
+        $this->caBundle = $plain->getCaBundle();
+
+        return $this;
+    }
+
+    /**
      * Get the crt.
      *
      * @return string The crt.

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -68,4 +68,21 @@ class ConverterTest extends TestCase
 
         unlink(__DIR__.'/example.com.zip');
     }
+
+    public function testPlainToPlainString()
+    {
+        $plain = (new Plain())
+            ->setCrt(TestCertificate::CRT)
+            ->setKey(TestCertificate::KEY)
+            ->setCaBundle(TestCertificate::CA_BUNDLE);
+
+        $converter = (new Converter())
+            ->from($plain)
+            ->to(new Plain());
+
+        $this->assertSame(
+            TestCertificate::CRT.TestCertificate::KEY.TestCertificate::CA_BUNDLE,
+            $converter->asString()
+        );
+    }
 }


### PR DESCRIPTION
## Description
Set the crt, key and bundle fields using setPlain.

## Checklist:
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have added the appropriate labels to my pull request (e.g. breaking-change, new-feature, bugfix).
