### PR TITLE
Use SplTempFileObject as response for asZip()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ $pem = $converter
     ->from($plain)
     ->to(new Pem());
 
-// Save as zip file.
-$pem->asZip('./');
+// Get certificate files as a zip file.
+$zipFile = $pem->asZip(); // SplTempFileObject
 
 // Get an array with the certificate files:
 print_r($pem->asFiles());

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -98,36 +98,22 @@ class Converter
     }
 
     /**
-     * Convert the input format to the provided output format and save the file (or files) as zip.
-     *
-     * @param string $path The path where to store the zip file.
+     * Convert the input format to the provided output format and zip the files.
      *
      * @throws Exceptions\InvalidResource            When the provided certificate is invalid.
      * @throws Exceptions\MissingRequiredInformation When some required certificate data is missing.
      * @throws ZipException                          When the files can not be zipped.
      *
-     * @return bool True when the zip is created and stored.
+     * @return \SplTempFileObject The zip file.
      */
-    public function asZip(string $path): bool
+    public function asZip(): \SplTempFileObject
     {
-        $filename = sprintf('%s/%s.zip', rtrim($path, '/'), $this->certificateName);
-
-        if (!is_dir($path) || !is_writable($path)) {
-            throw new ZipException(sprintf('The directory [%s] is does not exists or is not writable.', $path));
-        }
-
-        if (is_file($filename) && !is_writable($filename)) {
-            throw new ZipException(sprintf('The file [%s] already exists and is not writable.', $filename));
-        }
-
-        $files = $this->to
-            ->setName($this->certificateName)
-            ->setPlain($this->from->getPlain())
-            ->export();
+        $tempPath = tempnam(sys_get_temp_dir(), 'zip_');
 
         $zip = new \ZipArchive();
-        $zip->open($filename, \ZipArchive::CREATE);
-        foreach ($files as $name => $content) {
+        $zip->open($tempPath, \ZipArchive::CREATE);
+
+        foreach ($this->asFiles() as $name => $content) {
             $zip->addFromString($name, $content);
         }
 
@@ -137,6 +123,10 @@ class Converter
 
         $zip->close();
 
-        return file_exists($filename);
+        $zipTempFile = new \SplTempFileObject();
+        $zipTempFile->fwrite(file_get_contents($tempPath));
+        $zipTempFile->rewind();
+
+        return $zipTempFile;
     }
 }

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -62,11 +62,9 @@ class ConverterTest extends TestCase
             ->setName('example.com')
             ->to(new Pem());
 
-        $converter->asZip(__DIR__);
+        $zipFile = $converter->asZip();
 
-        $this->assertTrue(file_exists(__DIR__.'/example.com.zip'));
-
-        unlink(__DIR__.'/example.com.zip');
+        $this->assertInstanceOf(\SplTempFileObject::class, $zipFile);
     }
 
     public function testPlainToPlainString()


### PR DESCRIPTION
## Description
Separate concerns: This package should not be responsible for storing a file on disk and generating a filename.

**Before**
The `asZip()` method would write a file to disk and only return true|false to indicate success. The name of the file was generated but never returned which means using the method required you to use the same implementation to "generate" the filename ad retrieve the file contents.

**Now**
The response of the `asZip()` method returns a file object that contains the zip contents. this object can be passed around and the user is responsible for storing it (for example on disk). By using a [SplTempFileObject](https://www.php.net/manual/en/class.spltempfileobject.php) the file is auto cleaned up if not explicitly stored.

## Checklist:
- [x] My pull request addresses exactly one patch/feature.
- [x] My pull request contains a title that can be used as a release note.
- [x] I have added the appropriate labels to my pull request (e.g. breaking-change, new-feature, bugfix).
